### PR TITLE
Bump datadog-metric-wrapper from 0.1.1 to 1.1.2-wms-ob

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>com.mercadolibre.metrics</groupId>
 			<artifactId>datadog-metric-wrapper</artifactId>
-			<version>0.1.1</version>
+			<version>1.1.2-wms-ob</version>
 		</dependency>						
 	</dependencies>
 <dependencyManagement>


### PR DESCRIPTION
Bumps datadog-metric-wrapper from 0.1.1 to 1.1.2-wms-ob.
